### PR TITLE
Provide variadic function call operator for val

### DIFF
--- a/scm/list.hpp
+++ b/scm/list.hpp
@@ -51,6 +51,29 @@ struct list : detail::wrapper
     }
 };
 
+
+  /**
+   * Creates a (wrapped) scheme list of the arguments passed to listify.
+   *
+   * We couldn't make this a constructor for list because it would be
+   * confused with the copy constructor.
+   * It also not called make_list because there is already a
+   * scheme side constructor with the same name and different meaning
+   */
+list listify() { return list{}; }
+list listify(val a0) { return scm_list_1(a0); }
+list listify(val a0, val a1) { return scm_list_2(a0, a1); }
+list listify(val a0, val a1, val a2) { return scm_list_3(a0, a1, a2); }
+list listify(val a0, val a1, val a2, val a3)
+{ return scm_list_4(a0, a1, a2, a3); }
+list listify(val a0, val a1, val a2, val a3, val a4)
+{ return scm_list_5(a0, a1, a2, a3, a4); }
+
+template<typename...T, typename = std::enable_if<(sizeof...(T) > 5), void>>
+list listify(T...arg){
+  return scm_list_n(arg...,SCM_UNDEFINED);
+}
+
 /**
  * C++ representation of a Scheme list that when used at the end of a
  * function, will capture the *rest* arguments.

--- a/scm/val.hpp
+++ b/scm/val.hpp
@@ -135,11 +135,14 @@ struct val : detail::wrapper
      * calls the Scheme procedure with the given arguments.  They
      * arguments may be implicitly converted from C++.
      */
-    template <typename... T>
-    val operator()(T... arg) const
-    {
-      return detail::scm_funcall_impl(get(),arg...);
-    }
+    val operator() () const
+    { return val{scm_call_0(get())}; }
+    val operator() (val a0) const
+    { return val{scm_call_1(get(), a0)}; }
+    val operator() (val a0, val a1) const
+    { return val{scm_call_2(get(), a0, a1)}; }
+    val operator() (val a0, val a1, val a3) const
+    { return val{scm_call_3(get(), a0, a1, a3)}; }
 };
 
 } // namespace scm

--- a/scm/val.hpp
+++ b/scm/val.hpp
@@ -34,6 +34,49 @@ protected:
     SCM handle_ = SCM_UNSPECIFIED;
 };
 
+struct big
+{};
+struct small
+{};
+template <typename... T>
+using scm_call_size = std::conditional_t<(sizeof...(T) <= 9), small, big>;
+
+template <int nargs>
+constexpr auto dispatch_small_scm_call()
+{
+    if (nargs == 0)
+        return scm_call_0;
+    else if (nargs == 1)
+        return scm_call_1;
+    else if (nargs == 2)
+        return scm_call_2;
+    else if (nargs == 3)
+        return scm_call_3;
+    else if (nargs == 4)
+        return scm_call_4;
+    else if (nargs == 5)
+        return scm_call_5;
+    else if (nargs == 6)
+        return scm_call_6;
+    else if (nargs == 7)
+        return scm_call_7;
+    else if (nargs == 8)
+        return scm_call_8;
+    else if (nargs == 9)
+        return scm_call_9;
+}
+
+template <typename... T>
+SCM scm_funcall_impl(small, SCM f, T... arg)
+{
+  return dispatch_small_scm_call(f,arg...);
+}
+
+template <typename... T>
+SCM scm_funcall_impl(big, SCM f, T... arg)
+{
+    return scm_call(f, arg..., SCM_UNDEFINED);
+}
 } // namespace detail
 
 /**
@@ -89,35 +132,7 @@ struct val : detail::wrapper
     template <typename... T>
     val operator()(T... arg) const
     {
-        constexpr auto nargs = sizeof...(arg);
-        constexpr auto scm_call_fn = [nargs]() {
-            if (nargs == 0) {
-                return scm_call_0;
-            } else if (nargs == 1) {
-                return scm_call_1;
-            } else if (nargs == 2) {
-                return scm_call_2;
-            } else if (nargs == 3) {
-                return scm_call_3;
-            } else if (nargs == 4) {
-                return scm_call_4;
-            } else if (nargs == 5) {
-                return scm_call_5;
-            } else if (nargs == 6) {
-                return scm_call_6;
-            } else if (nargs == 7) {
-                return scm_call_7;
-            } else if (nargs == 8) {
-                return scm_call_8;
-            } else if (nargs == 9) {
-                return scm_call_9;
-            } else {
-                return [](SCM f, auto... arg) {
-                    return scm_call(f, arg..., SCM_UNDEFINED);
-                };
-            }
-        }();
-        return scm_call_fn(get(), val{arg}...);
+      return detail::scm_funcall_impl(get(),arg...);
     }
 };
 

--- a/scm/val.hpp
+++ b/scm/val.hpp
@@ -69,7 +69,7 @@ constexpr auto dispatch_small_scm_call()
 template <typename... T>
 SCM scm_funcall_dispatch(small, SCM f, T... arg)
 {
-  return dispatch_small_scm_call()(f,arg...);
+  return dispatch_small_scm_call<sizeof...(T)>()(f,arg...);
 }
 
 template <typename... T>

--- a/scm/val.hpp
+++ b/scm/val.hpp
@@ -67,15 +67,21 @@ constexpr auto dispatch_small_scm_call()
 }
 
 template <typename... T>
-SCM scm_funcall_impl(small, SCM f, T... arg)
+SCM scm_funcall_dispatch(small, SCM f, T... arg)
 {
   return dispatch_small_scm_call(f,arg...);
 }
 
 template <typename... T>
-SCM scm_funcall_impl(big, SCM f, T... arg)
+SCM scm_funcall_dispatch(big, SCM f, T... arg)
 {
     return scm_call(f, arg..., SCM_UNDEFINED);
+}
+
+template <typename... T>
+SCM scm_funcall_impl(SCM f, T... arg)
+{
+    return scm_funcall_dispatch(scm_call_size<T...>{}, arg...);
 }
 } // namespace detail
 

--- a/scm/val.hpp
+++ b/scm/val.hpp
@@ -33,56 +33,6 @@ struct wrapper
 protected:
     SCM handle_ = SCM_UNSPECIFIED;
 };
-
-struct big
-{};
-struct small
-{};
-template <typename... T>
-using scm_call_size = std::conditional_t<(sizeof...(T) <= 9), small, big>;
-
-template <int nargs>
-constexpr auto dispatch_small_scm_call()
-{
-    if (nargs == 0)
-        return scm_call_0;
-    else if (nargs == 1)
-        return scm_call_1;
-    else if (nargs == 2)
-        return scm_call_2;
-    else if (nargs == 3)
-        return scm_call_3;
-    else if (nargs == 4)
-        return scm_call_4;
-    else if (nargs == 5)
-        return scm_call_5;
-    else if (nargs == 6)
-        return scm_call_6;
-    else if (nargs == 7)
-        return scm_call_7;
-    else if (nargs == 8)
-        return scm_call_8;
-    else if (nargs == 9)
-        return scm_call_9;
-}
-
-template <typename... T>
-SCM scm_funcall_dispatch(small, SCM f, T... arg)
-{
-  return dispatch_small_scm_call<sizeof...(T)>()(f,arg...);
-}
-
-template <typename... T>
-SCM scm_funcall_dispatch(big, SCM f, T... arg)
-{
-    return scm_call(f, arg..., SCM_UNDEFINED);
-}
-
-template <typename... T>
-SCM scm_funcall_impl(SCM f, T... arg)
-{
-    return scm_funcall_dispatch(scm_call_size<T...>{}, arg...);
-}
 } // namespace detail
 
 /**

--- a/scm/val.hpp
+++ b/scm/val.hpp
@@ -69,7 +69,7 @@ constexpr auto dispatch_small_scm_call()
 template <typename... T>
 SCM scm_funcall_dispatch(small, SCM f, T... arg)
 {
-  return dispatch_small_scm_call(f,arg...);
+  return dispatch_small_scm_call()(f,arg...);
 }
 
 template <typename... T>

--- a/scm/val.hpp
+++ b/scm/val.hpp
@@ -141,8 +141,25 @@ struct val : detail::wrapper
     { return val{scm_call_1(get(), a0)}; }
     val operator() (val a0, val a1) const
     { return val{scm_call_2(get(), a0, a1)}; }
-    val operator() (val a0, val a1, val a3) const
-    { return val{scm_call_3(get(), a0, a1, a3)}; }
+    val operator() (val a0, val a1, val a2) const
+    { return val{scm_call_3(get(), a0, a1, a2)}; }
+    val operator() (val a0, val a1, val a2, val a3) const
+    { return val{scm_call_4(get(), a0, a1, a2, a3)}; }
+    val operator() (val a0, val a1, val a2, val a3, val a4) const
+    { return val{scm_call_5(get(), a0, a1, a2, a3, a4)}; }
+    val operator() (val a0, val a1, val a2, val a3, val a4, val a5) const
+    { return val{scm_call_6(get(), a0, a1, a2, a3, a4, a5)}; }
+    val operator() (val a0, val a1, val a2, val a3, val a4, val a5, val a6) const
+    { return val{scm_call_7(get(), a0, a1, a2, a3, a4, a5, a6)}; }
+    val operator() (val a0, val a1, val a2, val a3, val a4, val a5, val a6,val a7) const
+    { return val{scm_call_8(get(), a0, a1, a2, a3, a4, a5, a6,a7)}; }
+    val operator() (val a0, val a1, val a2, val a3, val a4, val a5, val a6,val a7, val a8) const
+    { return val{scm_call_9(get(), a0, a1, a2, a3, a4, a5, a6,a7,a8)}; }
+
+    template<typename...T, typename = std::enable_if<(sizeof...(T) > 9), void>>
+    val operator() (T...arg) const{
+      return val{scm_call(get(),arg...,SCM_UNDEFINED)};
+    }
 };
 
 } // namespace scm

--- a/scm/val.hpp
+++ b/scm/val.hpp
@@ -86,14 +86,35 @@ struct val : detail::wrapper
      * calls the Scheme procedure with the given arguments.  They
      * arguments may be implicitly converted from C++.
      */
-    val operator() () const
-    { return val{scm_call_0(get())}; }
-    val operator() (val a0) const
-    { return val{scm_call_1(get(), a0)}; }
-    val operator() (val a0, val a1) const
-    { return val{scm_call_2(get(), a0, a1)}; }
-    val operator() (val a0, val a1, val a3) const
-    { return val{scm_call_3(get(), a0, a1, a3)}; }
+    template<typename...T>
+    val operator()(T...arg) const {
+      static_assert((std::is_convertible_v<T,val> && ...),
+                    "Arguments must be implicitly convertible to val");
+      constexpr auto nargs = sizeof...(arg);
+      if constexpr(nargs == 0){
+        return scm_call_0(get());
+      } else if (nargs == 1){
+        return scm_call_1(get(),arg...);
+      } else if (nargs == 2){
+        return scm_call_2(get(),arg...);
+      } else if (nargs == 3){
+        return scm_call_3(get(),arg...);
+      } else if (nargs == 4){
+        return scm_call_4(get(),arg...);
+      } else if (nargs == 5){
+        return scm_call_5(get(),arg...);
+      } else if (nargs == 6){
+        return scm_call_6(get(),arg...);
+      } else if (nargs == 7){
+        return scm_call_7(get(),arg...);
+      } else if (nargs == 8){
+        return scm_call_8(get(),arg...);
+      } else if (nargs == 9){
+        return scm_call_9(get(),arg...);
+      } else{
+        return scm_call(get(),arg...,SCM_UNDEFINED);
+      }
+    }
 };
 
 } // namespace scm

--- a/scm/val.hpp
+++ b/scm/val.hpp
@@ -86,34 +86,38 @@ struct val : detail::wrapper
      * calls the Scheme procedure with the given arguments.  They
      * arguments may be implicitly converted from C++.
      */
-    template<typename...T>
-    val operator()(T...arg) const {
-      static_assert((std::is_convertible_v<T,val> && ...),
-                    "Arguments must be implicitly convertible to val");
-      constexpr auto nargs = sizeof...(arg);
-      if constexpr(nargs == 0){
-        return scm_call_0(get());
-      } else if (nargs == 1){
-        return scm_call_1(get(),arg...);
-      } else if (nargs == 2){
-        return scm_call_2(get(),arg...);
-      } else if (nargs == 3){
-        return scm_call_3(get(),arg...);
-      } else if (nargs == 4){
-        return scm_call_4(get(),arg...);
-      } else if (nargs == 5){
-        return scm_call_5(get(),arg...);
-      } else if (nargs == 6){
-        return scm_call_6(get(),arg...);
-      } else if (nargs == 7){
-        return scm_call_7(get(),arg...);
-      } else if (nargs == 8){
-        return scm_call_8(get(),arg...);
-      } else if (nargs == 9){
-        return scm_call_9(get(),arg...);
-      } else{
-        return scm_call(get(),arg...,SCM_UNDEFINED);
-      }
+    template <typename... T>
+    val operator()(T... arg) const
+    {
+        constexpr auto nargs = sizeof...(arg);
+        constexpr auto scm_call_fn = [nargs]() {
+            if (nargs == 0) {
+                return scm_call_0;
+            } else if (nargs == 1) {
+                return scm_call_1;
+            } else if (nargs == 2) {
+                return scm_call_2;
+            } else if (nargs == 3) {
+                return scm_call_3;
+            } else if (nargs == 4) {
+                return scm_call_4;
+            } else if (nargs == 5) {
+                return scm_call_5;
+            } else if (nargs == 6) {
+                return scm_call_6;
+            } else if (nargs == 7) {
+                return scm_call_7;
+            } else if (nargs == 8) {
+                return scm_call_8;
+            } else if (nargs == 9) {
+                return scm_call_9;
+            } else {
+                return [](SCM f, auto... arg) {
+                    return scm_call(f, arg..., SCM_UNDEFINED);
+                };
+            }
+        }();
+        return scm_call_fn(get(), val{arg}...);
     }
 };
 


### PR DESCRIPTION
The function call operator in val.hpp can be written to use variadic arguments. 
The implementation here uses fold expressions from C++17, but everything except the static assert conforms to C++14 I believe.