### PR TITLE
Add converter from/to scm and cpp for booleans

### DIFF
--- a/scm/detail/convert.hpp
+++ b/scm/detail/convert.hpp
@@ -32,6 +32,13 @@ auto to_cpp(SCM v)
     -> SCM_DECLTYPE_RETURN(
         convert<std::decay_t<T>>::to_cpp(v));
 
+/// convert is specialized for bool, since loading and writing has a different syntax in libguile
+template<>
+struct convert<bool> {
+    static bool to_cpp(SCM v) { return scm_is_true(v) == 1; }
+    static SCM to_scm(bool v) { return scm_from_bool(static_cast<int>(v)); }
+};
+
 } // namespace detail
 } // namespace scm
 


### PR DESCRIPTION
I use schmutz for guile bindings to provide a custom DSL for users.
In that case there are functions where passing #false / #true instead of equivalent numbers results in better readability of client code.

The generic converter does not cover booleans as the conversion patterns don't match the same patterns as numeric values.