### PR TITLE
Fix -wpedantic warnings in schmutz

### DIFF
--- a/scm/detail/convert.hpp
+++ b/scm/detail/convert.hpp
@@ -25,12 +25,12 @@ struct convert;
 template <typename T>
 auto to_scm(T&& v)
     -> SCM_DECLTYPE_RETURN(
-        convert<std::decay_t<T>>::to_scm(std::forward<T>(v)));
+        convert<std::decay_t<T>>::to_scm(std::forward<T>(v)))
 
 template <typename T>
 auto to_cpp(SCM v)
     -> SCM_DECLTYPE_RETURN(
-        convert<std::decay_t<T>>::to_cpp(v));
+        convert<std::decay_t<T>>::to_cpp(v))
 
 /// convert is specialized for bool, since loading and writing has a different syntax in libguile
 template<>

--- a/scm/list.hpp
+++ b/scm/list.hpp
@@ -85,5 +85,5 @@ struct args : list
 
 } // namespace scm
 
-SCM_DECLARE_WRAPPER_TYPE(scm::list);
-SCM_DECLARE_WRAPPER_TYPE(scm::args);
+SCM_DECLARE_WRAPPER_TYPE(scm::list)
+SCM_DECLARE_WRAPPER_TYPE(scm::args)

--- a/scm/val.hpp
+++ b/scm/val.hpp
@@ -123,4 +123,4 @@ struct val : detail::wrapper
     }} /* namespace scm::detail */                                      \
     /**/
 
-SCM_DECLARE_WRAPPER_TYPE(val);
+SCM_DECLARE_WRAPPER_TYPE(val)


### PR DESCRIPTION
Nothing major, just made it compile with `-wpedantic` without compiler warnings.