### PR TITLE
let scm_c_export terminated by ‘nullptr’.

### DIFF
--- a/scm/detail/define.hpp
+++ b/scm/detail/define.hpp
@@ -28,7 +28,7 @@ static void define_impl(const std::string& name, Fn fn)
     auto subr = (scm_t_subr) +subr_wrapper_aux<Tag>(fn, args_t{});
     scm_c_define_gsubr(name.c_str(), arg_count, 0, has_rest, subr);
 #if SCM_AUTO_EXPORT
-    scm_c_export(name.c_str());
+    scm_c_export(name.c_str(),nullptr);
 #endif
 }
 

--- a/scm/type.hpp
+++ b/scm/type.hpp
@@ -96,7 +96,7 @@ struct type_definer : move_sequence
             scm_c_define(define_name.c_str(), foreign_type);
             storage_t::data = foreign_type;
 #if SCM_AUTO_EXPORT
-            scm_c_export(define_name.c_str());
+            scm_c_export(define_name.c_str(),nullptr);
 #endif
         }
     }


### PR DESCRIPTION
see https://www.gnu.org/software/guile/manual/html_node/Accessing-Modules-from-C.html#index-scm_005fc_005fexport

 -- C Function: void scm_c_export (const char *NAME, ...)
     Add the bindings designated by NAME, ...  to the public interface
     of the current module.  The list of names is terminated by ‘NULL’.

